### PR TITLE
Added support for sarif reporting

### DIFF
--- a/Dockerfiles/Dockerfile.python3.10
+++ b/Dockerfiles/Dockerfile.python3.10
@@ -23,9 +23,12 @@ RUN set -eux \
 	\
 	&& pip3 install --no-cache-dir \
 		lxml \
+	&& pip3 install --no-cache-dir \
+		bandit_sarif_formatter \
 	\
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf
+
 
 
 FROM alpine:3.16 as production

--- a/Dockerfiles/Dockerfile.python3.7
+++ b/Dockerfiles/Dockerfile.python3.7
@@ -23,6 +23,8 @@ RUN set -eux \
 	\
 	&& pip3 install --no-cache-dir \
 		lxml \
+	&& pip3 install --no-cache-dir \
+		bandit_sarif_formatter \
 	\
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf

--- a/Dockerfiles/Dockerfile.python3.8
+++ b/Dockerfiles/Dockerfile.python3.8
@@ -23,6 +23,8 @@ RUN set -eux \
 	\
 	&& pip3 install --no-cache-dir \
 		lxml \
+	&& pip3 install --no-cache-dir \
+		bandit_sarif_formatter \
 	\
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf

--- a/Dockerfiles/Dockerfile.python3.9
+++ b/Dockerfiles/Dockerfile.python3.9
@@ -23,6 +23,8 @@ RUN set -eux \
 	\
 	&& pip3 install --no-cache-dir \
 		lxml \
+	&& pip3 install --no-cache-dir \
+		bandit_sarif_formatter \
 	\
 	&& find /usr/lib/ -name '__pycache__' -print0 | xargs -0 -n1 rm -rf \
 	&& find /usr/lib/ -name '*.pyc' -print0 | xargs -0 -n1 rm -rf


### PR DESCRIPTION
Hi!

This pull-request provided the option of using saris formatting for bandit, all Dockerfiles were changed and tested (Using a Mac M1 but I don't see why other arquitectares would have a problem with a simple pip install).

The change only revolves around the install of the [bandit sarif formatter](https://github.com/microsoft/bandit-sarif-formatter) python module.

Hope this is useful and can be integrated into the project as it would be of great help to me as well.